### PR TITLE
Fix plugin_version display for example in plugin list

### DIFF
--- a/simple-example/src/lib.rs
+++ b/simple-example/src/lib.rs
@@ -12,16 +12,19 @@ macro_rules! cstr {
 
 // Plugin version string
 #[no_mangle]
+#[allow(non_upper_case_globals)]
 #[used]
-pub static plugin_version: &'static CStr = unsafe { CStr::from_ptr(cstr!("1.0.0")) };
+pub static plugin_version: [u8; 6] = [b'1', b'.', b'0', b'.', b'0', b'\0'];
 
 // Major version of Wireshark that the plugin is built for
 #[no_mangle]
+#[allow(non_upper_case_globals)]
 #[used]
 pub static plugin_want_major: c_int = 4;
 
 // Minor version of Wireshark that the plugin is built for
 #[no_mangle]
+#[allow(non_upper_case_globals)]
 #[used]
 pub static plugin_want_minor: c_int = 4;
 


### PR DESCRIPTION
Currently the example plugin results in a messed up plugin list when running "tshark -G plugins" and in Wireshark.

This replaces the C string with a char array. Also warnings for the names of the exported symbols are fixed.

Now:

```
l16mono.so      	0.1.0	codec	/usr/lib/wireshark/plugins/4.4/codecs/l16mono.so
qbyfoo.sunknown	/home/johannes/.local/lib/wireshark/plugins/4.4/epan/libfoo.so
mate.so         	1.0.1	dissector	/usr/lib/wireshark/plugins/4.4/epan/mate.so
```

With this fix:
```

l16mono.so      	0.1.0	codec	/usr/lib/wireshark/plugins/4.4/codecs/l16mono.so
libfoo.so       	1.0.0	unknown	/home/johannes/.local/lib/wireshark/plugins/4.4/epan/libfoo.so
mate.so         	1.0.1	dissector	/usr/lib/wireshark/plugins/4.4/epan/mate.so
```